### PR TITLE
Supporting "Date" and "Time" type

### DIFF
--- a/lib/json_mapper/attribute.rb
+++ b/lib/json_mapper/attribute.rb
@@ -41,6 +41,8 @@ class Attribute
       end
     elsif self.type == Boolean then return %w(true t 1).include?(value.to_s.downcase)
     elsif self.type == DateTime then return Date.parse(value.to_s)
+    elsif self.type == Date then return Date.parse(value.to_s)
+    elsif self.type == Time then return Time.parse(value.to_s)
     else
 
       # If our type is a JSONMapper instance, delegate the

--- a/test/fixtures/simple.json
+++ b/test/fixtures/simple.json
@@ -3,5 +3,7 @@
   "money": 125.50,
   "title": "Simple JSON title",
   "boolean": true,
-  "datetime": "2010-10-08 17:59:46"
+  "datetime": "2010-10-08 17:59:46",
+  "date": "2016-08-22 19:34:03",
+  "time": "2016-08-23 19:56:47"
 }

--- a/test/json_mapper_test.rb
+++ b/test/json_mapper_test.rb
@@ -46,6 +46,8 @@ class JSONMapperTest < Test::Unit::TestCase
       model.title.should == "Simple JSON title"
       model.boolean.should == true
       model.datetime.should == Date.parse("2010-10-08 17:59:46")
+      model.date.should == Date.parse("2016-08-22 19:34:03")
+      model.time.should == Time.parse("2016-08-23 19:56:47")
     end
 
     should "assign value from different sources into an attribute" do

--- a/test/support/models.rb
+++ b/test/support/models.rb
@@ -7,6 +7,8 @@ class SimpleModel
   json_attribute :title, String
   json_attribute :boolean, Boolean
   json_attribute :datetime, DateTime
+  json_attribute :date, Date
+  json_attribute :time, Time
 
 end
 


### PR DESCRIPTION
I added "Date" and "Time" type of attribute, because "DateTime" attribute is converted to "Date" type actually.

Considering some impacts on users of this gem, I add them in addition to DateTime.
But I think It's better that DateTime attribute is mapped as "DateTime" or "Time" object (not Date object) if you think there's no problem.
